### PR TITLE
Enable parsing of hh:mm time strings

### DIFF
--- a/src/CFTime.jl
+++ b/src/CFTime.jl
@@ -495,7 +495,16 @@ function parseDT(::Type{DT},str) where DT <: Union{DateTime,AbstractCFDateTime}
             (y,m,d,h,mi,s,Int64(0))
             =#
 
-            h_str, mi_str, s_str = split(timestr,':')
+            time_split = split(timestr,':')
+
+            h_str, mi_str, s_str =
+                if length(time_split) == 2
+                    time_split[1], time_split[2], "00"
+                else
+                    time_split
+                end
+
+
             h = parse(Int64,h_str)
             mi = parse(Int64,mi_str)
 

--- a/test/test_time.jl
+++ b/test/test_time.jl
@@ -148,6 +148,9 @@ t0,plength = CFTime.timeunits("days since 2000-01-01 0:0:0")
 @test t0 == DateTimeStandard(2000,1,1)
 @test plength == 86400000
 
+t0,plength = CFTime.timeunits("days since 2000-01-01 00:00")
+@test t0 == DateTimeStandard(2000,1,1)
+@test plength == 86400000
 
 # issue 24
 t0,plength = CFTime.timeunits("hours since 1900-01-01 00:00:00.0")


### PR DESCRIPTION
Currently this date and time format throws an error:
```julia
timedecode(4.0,"days since 2001-01-01 00:00","gregorian")
```
where only hour and minutes of the reference time are given. This would be fixed by this PR. 