### PR TITLE
Split time zone info if it is given

### DIFF
--- a/src/CFTime.jl
+++ b/src/CFTime.jl
@@ -506,8 +506,14 @@ function parseDT(::Type{DT},str) where DT <: Union{DateTime,AbstractCFDateTime}
             timestr,tz = if occursin("+",timestr)
               ts,tz = split(timestr,"+")
               ts,tz
+            elseif occursin("-",timestr)
+              ts,tz = split(timestr,"-")
+              ts,string("-",tz)
             else
               timestr, "00:00"
+            end
+            if !all(iszero(parse.(Int,split(tz,":"))))
+              @warn "Time zones are currently not supported by CFTime. Ignoring Time zone information: $(tz)"
             end
 
             time_split = split(timestr,':')

--- a/src/CFTime.jl
+++ b/src/CFTime.jl
@@ -503,9 +503,14 @@ function parseDT(::Type{DT},str) where DT <: Union{DateTime,AbstractCFDateTime}
 
             (y,m,d,h,mi,s,Int64(0))
             =#
+            timestr,tz = if occursin("+",timestr)
+              ts,tz = split(timestr,"+")
+              ts,tz
+            else
+              timestr, "00:00"
+            end
 
             time_split = split(timestr,':')
-
             h_str, mi_str, s_str =
                 if length(time_split) == 2
                     time_split[1], time_split[2], "00"
@@ -516,7 +521,6 @@ function parseDT(::Type{DT},str) where DT <: Union{DateTime,AbstractCFDateTime}
 
             h = parse(Int64,h_str)
             mi = parse(Int64,mi_str)
-
             s,ms =
                 if occursin('.',s_str)
                     # seconds contain a decimal point, e.g. 00:00:00.0

--- a/test/test_time.jl
+++ b/test/test_time.jl
@@ -420,3 +420,25 @@ data = [0,1,2,3]
 dt = CFTime.timedecode(DateTime360Day,data,"days since 2000-01-01 00:00:00")
 data2 = CFTime.timeencode(dt,"days since 2000-01-01 00:00:00",DateTime360Day)
 @test data == data2
+
+#issue #6
+
+data = [0,1,2,3]
+dt = CFTime.timedecode(DateTime,data,"days since 2000-01-01 00:00:00+00")
+data2 = CFTime.timeencode(dt,"days since 2000-01-01 00:00:00+00",DateTime)
+@test data == data2
+
+data = [0,1,2,3]
+dt = CFTime.timedecode(DateTime360Day,data,"days since 2000-01-01 00:00:00+00:00")
+data2 = CFTime.timeencode(dt,"days since 2000-01-01 00:00:00+00:00",DateTime360Day)
+@test data == data2
+
+data = [0,1,2,3]
+dt = CFTime.timedecode(DateTime,data,"days since 2000-01-01 00:00:00+01")
+data2 = CFTime.timeencode(dt,"days since 2000-01-01 00:00:00+00",DateTime)
+@test data == data2
+
+data = [0,1,2,3]
+dt = CFTime.timedecode(DateTime360Day,data,"days since 2000-01-01 00:00:00-01:00")
+data2 = CFTime.timeencode(dt,"days since 2000-01-01 00:00:00+00:00",DateTime360Day)
+@test data == data2


### PR DESCRIPTION
I just stumbled over this time unit string: `"seconds since 1970-01-01T00:00:00+00:00"` which threw an error because of the additional time zone information. This branch fixes the bug for now by simply throwing away the time zone information. Do you think it is ok to just ignore this? Maybe it would make sense to show a warning whenever the time shift is not equal to zero.