### PR TITLE
fix: Base.show method for AbstractCFDateTime

### DIFF
--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -362,7 +362,11 @@ function string(dt::T)  where T <: AbstractCFDateTime
 end
 
 function show(io::IO,dt::T)  where T <: AbstractCFDateTime
-    println(io, string(typeof(dt).name.name), "(",string(dt),")")
+    if dt isa get(io, :typeinfo, Any) <: AbstractCFDateTime
+        print(io, string(dt))
+    else
+        print(io, string(nameof(T)), "(",string(dt),")")
+    end
 end
 
 


### PR DESCRIPTION
This pull request refines the `show` function in `src/datetime.jl` for improved type handling and output formatting. Key points:
* replace `println` by `print`. Notice the additional newlines below
* use the `:typeinfo` flag to detect redundant type information during printing.
* Use `nameof(T)` instead of reaching into internals, `T.name.name`

Before:
```
julia> p = DateTimeStandard(1582,10,4)
DateTimeStandard(1582-10-04T00:00:00)


julia> [p, p]
2-element Vector{DateTimeStandard{CFTime.Period{Int64, Val{1}(), Val{-3}()}, Val{(1900, 1, 1)}()}}:
 DateTimeStandard(1582-10-04T00:00:00)

 DateTimeStandard(1582-10-04T00:00:00)


```
now:
```
julia> p
DateTimeStandard(1582-10-04T00:00:00)

julia> [p, p]
2-element Vector{DateTimeStandard{CFTime.Period{Int64, Val{1}(), Val{-3}()}, Val{(1900, 1, 1)}()}}:
 1582-10-04T00:00:00
 1582-10-04T00:00:00

```

There may be some additional work needed to improve the printing experience, as I'm not sure that the verbose type info is useful. This comment is raised separately in #44.

---

ref: https://github.com/openjournals/joss-reviews/issues/8487