### PR TITLE
docs: add xrefs to docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,16 +4,16 @@ In many Earth science disciplines and beyond, expressing a time instance and a d
 
 CFTime.jl implements the time structures standardized by the CF conventions, namely:
 
-* Julian calendar (`DateTimeJulian`). A year is a leap year if it is divisible by 4. For example, 1900 and 2000 are both leap years in the Julian calendar.
-* Proleptic Gregorian calendar (`DateTimeProlepticGregorian`). A year is a leap year if it is divisible by 4 but not 100 or if it is divisible by 400. For example, 1900 is not a leap year in the proleptic Gregorian calendar but 2000 is.
-* The default mixed Gregorian/Julian calendar  (`DateTimeStandard`). This calendar uses the Julian calendar for time instances before 15th October 1582 and Gregorian calendar afterwards.
-* A calendar without leap years (`DateTimeNoLeap`). All years are 365 days long.
-* A calendar with only leap years (`DateTimeAllLeap`). All years are 366 days long.
-* A calendar with every year being 360 days long (divided into 30-day months) (`DateTime360Day`).
+* Julian calendar ([`DateTimeJulian`](@ref)). A year is a leap year if it is divisible by 4. For example, 1900 and 2000 are both leap years in the Julian calendar.
+* Proleptic Gregorian calendar ([`DateTimeProlepticGregorian`](@ref)). A year is a leap year if it is divisible by 4 but not 100 or if it is divisible by 400. For example, 1900 is not a leap year in the proleptic Gregorian calendar but 2000 is.
+* The default mixed Gregorian/Julian calendar  ([`DateTimeStandard`](@ref)). This calendar uses the Julian calendar for time instances before 15th October 1582 and Gregorian calendar afterwards.
+* A calendar without leap years ([`DateTimeNoLeap`](@ref)). All years are 365 days long.
+* A calendar with only leap years ([`DateTimeAllLeap`](@ref)). All years are 366 days long.
+* A calendar with every year being 360 days long (divided into 30-day months) ([`DateTime360Day`](@ref)).
 
 The first three calendars (with different rules for leap years) can be used to express the time instances of observations or model. The remaining three calendars correspond to idealised model configurations where the duration of a year (revolution of the Earth around the Sun) is assumed to be exactly 365, 366 or 360 days.
 
-While almost all datasets used in Earth Science use dates after the year 1582, some datasets or software systems use a time origin before this date, which makes it necessary to handle the transition from Julian to Gregorian calendar. Additionally, some dataset use microseconds and nanoseconds as time resolution, whereas Julia's `Dates.DateTime` has milliseconds as time resolution.
+While almost all datasets used in Earth Science use dates after the year 1582, some datasets or software systems use a time origin before this date, which makes it necessary to handle the transition from Julian to Gregorian calendar. Additionally, some dataset use microseconds and nanoseconds as time resolution, whereas Julia's [`Dates.DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime) has milliseconds as time resolution.
 
 Note that time zones and leap seconds are currently not supported by `CFTime.jl`.
 
@@ -27,7 +27,7 @@ using Pkg
 Pkg.add("CFTime")
 ```
 
-CFTime is a pure Julia package and currently depends only on the modules `Dates` and `Printf`, which are part of Julia’s standard library.
+CFTime is a pure Julia package and currently depends only on the modules [`Dates`](https://docs.julialang.org/en/v1/stdlib/Dates/) and [`Printf`](https://docs.julialang.org/en/v1/stdlib/Printf/), which are part of Julia’s standard library.
 
 
 ### Latest development version
@@ -41,7 +41,7 @@ Pkg.add(PackageSpec(url="https://github.com/JuliaGeo/CFTime.jl", rev="master"))
 
 ## Types
 
-`DateTimeStandard`, `DateTimeProlepticGregorian`, `DateTimeJulian`, `DateTimeNoLeap`, `DateTimeAllLeap` and `DateTime360Day` are the core types that define time instances according to the corresponding calendars. The main focus of this package is to instantiate and to manipulate these types.
+[`DateTimeStandard`](@ref), [`DateTimeProlepticGregorian`](@ref), [`DateTimeJulian`](@ref), [`DateTimeNoLeap`](@ref), [`DateTimeAllLeap`](@ref) and [`DateTime360Day`](@ref) are the core types that define time instances according to the corresponding calendars. The main focus of this package is to instantiate and to manipulate these types.
 
 ```@docs
 DateTimeStandard
@@ -91,9 +91,9 @@ dayofyear
 ## Conversion Functions
 
 
-The flexibility of CFTime's datetime (related to the time origin, time resolution and type of the time counter) comes with some cost. When merging data from different sources, the resulting merged time vector may not have a concrete type, as there is no implicit conversion to a common time origin or internal unit, unlike Julia's `DateTime`. In some cases, the user might decide to explicitly convert all times to a common time origin and internal unit for optimal performance.
+The flexibility of CFTime's datetime (related to the time origin, time resolution and type of the time counter) comes with some cost. When merging data from different sources, the resulting merged time vector may not have a concrete type, as there is no implicit conversion to a common time origin or internal unit, unlike Julia's [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime). In some cases, the user might decide to explicitly convert all times to a common time origin and internal unit for optimal performance.
 
-The `convert` function can be used to convert dates between the different calendars:
+The [`convert`](@ref) function can be used to convert dates between the different calendars:
 
 ```julia
 using CFTime, Dates

--- a/src/CFTime.jl
+++ b/src/CFTime.jl
@@ -1,5 +1,7 @@
 """
 `CFTime` encodes and decodes time units conforming to the Climate and Forecasting (CF) netCDF conventions.
+Read more about the CF conventions [here](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#calendar).
+
 For example:
 
 ```julia
@@ -9,9 +11,9 @@ dt = CFTime.timedecode([0,1,2,3],"days since 2000-01-01 00:00:00",DateTime360Day
 # Encoding
 CFTime.timeencode(dt,"days since 2000-01-01 00:00:00",DateTime360Day)
 ```
-The following types are supported `DateTime`,
-`DateTimeStandard`, `DateTimeJulian`, `DateTimeProlepticGregorian`
-`DateTimeAllLeap`, `DateTimeNoLeap` and `DateTime360Day`
+The following types are supported [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime),
+[`DateTimeStandard`](@ref), [`DateTimeJulian`](@ref), [`DateTimeProlepticGregorian`](@ref),
+[`DateTimeAllLeap`](@ref), [`DateTimeNoLeap`](@ref) and [`DateTime360Day`](@ref)
 """
 module CFTime
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -64,9 +64,9 @@ end
 """
     dt2 = reinterpret(::Type{T}, dt)
 
-Convert a variable `dt` of type `DateTime`, `DateTimeStandard`, `DateTimeJulian`,
-`DateTimeProlepticGregorian`, `DateTimeAllLeap`, `DateTimeNoLeap` or
-`DateTime360Day` into the date time type `T` using the same values for
+Convert a variable `dt` of type [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime), [`DateTimeStandard`](@ref), [`DateTimeJulian`](@ref),
+[`DateTimeProlepticGregorian`](@ref), [`DateTimeAllLeap`](@ref), [`DateTimeNoLeap`](@ref) or
+[`DateTime360Day`](@ref) into the date time type `T` using the same values for
 year, month, day, minute, second, ... attosecond.
 The conversion might fail if a particular date does not exist in the
 target calendar.
@@ -313,7 +313,7 @@ Valid values for `calendar` are
 `"all_leap"`, `"366_day"` and `"360_day"`.
 
 If `prefer_datetime` is `true` (default), dates are
-converted to the `DateTime` type (for the calendars
+converted to the [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime) type (for the calendars
 "standard", "gregorian", "proleptic_gregorian" and "julian")
 unless the time unit is expressed in microseconds or smaller. Such conversion is
 not possible for the other calendars.
@@ -379,9 +379,9 @@ end
 """
     data = timeencode(dt,units,calendar = "standard")
 
-Convert a vector or array of `DateTime` (or `DateTimeStandard`,
-`DateTimeProlepticGregorian`, `DateTimeJulian`, `DateTimeNoLeap`,
-`DateTimeAllLeap`, `DateTime360Day`) according to
+Convert a vector or array of [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime) (or [`DateTimeStandard`](@ref),
+[`DateTimeProlepticGregorian`](@ref), [`DateTimeJulian`](@ref), [`DateTimeNoLeap`](@ref),
+[`DateTimeAllLeap`](@ref), [`DateTime360Day`](@ref)) according to
 the specified units (e.g. `"days since 2000-01-01 00:00:00"`) using the calendar
 `calendar`.
 
@@ -450,16 +450,16 @@ for CFDateTime in [:DateTimeStandard,
 """
     dt2 = convert(::Type{T}, dt)
 
-Convert a DateTime `dt` of type `DateTimeStandard`, `DateTimeProlepticGregorian`,
-`DateTimeJulian` or `DateTime` into the type `T` which can also be either
-`DateTimeStandard`, `DateTimeProlepticGregorian`, `DateTimeJulian` or `DateTime`.
+Convert a DateTime `dt` of type [`DateTimeStandard`](@ref), [`DateTimeProlepticGregorian`](@ref),
+[`DateTimeJulian`](@ref) or `DateTime` into the type `T` which can also be either
+[`DateTimeStandard`](@ref), [`DateTimeProlepticGregorian`](@ref), [`DateTimeJulian`](@ref) or [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime).
 
 Conversion is done such that duration (difference of DateTime types) are
 preserved. For dates on and after 1582-10-15, the year, month and days are the same for
-the types `DateTimeStandard`, `DateTimeProlepticGregorian` and `DateTime`.
+the types [`DateTimeStandard`](@ref), [`DateTimeProlepticGregorian`](@ref) and [`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime).
 
 For dates before 1582-10-15, the year, month and days are the same for
-the types `DateTimeStandard` and `DateTimeJulian`.
+the types [`DateTimeStandard`](@ref) and [`DateTimeJulian`](@ref).
 """
         function convert(::Type{DateTime}, dt::$CFDateTime)
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -11,7 +11,7 @@
     monthlength = daysinmonth(::Type{DT},y,m)
 
 Returns the number of days in a month for the year `y` and the month `m`
-according to the calendar given by the type `DT`.
+according to the calendar given by the type `DT` (any subtype of [`AbstractCFDateTime`](@ref)).
 
 Example
 ```julia-repl
@@ -44,7 +44,7 @@ end
     yearlength = daysinyear(::Type{DT},y)
 
 Returns the number of days in a year for the year `y`
-according to the calendar given by the type `DT`.
+according to the calendar given by the type `DT` (any subtype of [`AbstractCFDateTime`](@ref)).
 
 Example
 ```julia-repl

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -2,7 +2,11 @@
 """
     dtr = round(::Type{DateTime}, dt::Union{DateTimeProlepticGregorian,DateTimeStandard,DateTimeJulian},r = RoundNearestTiesUp)
 
-Round the date time `dt` to the nearest date time represenatable by julia's `DateTime` using the rounding mode `r` (either `RoundNearest` (default) `RoundDown` or `RoundUp`).
+Round the date time `dt` to the nearest date time represenatable by julia's
+[`DateTime`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateTime) using the rounding mode `r` (either
+[`RoundNearest`](https://docs.julialang.org/en/v1/base/math/#Base.Rounding.RoundNearest) (default),
+[`RoundDown`](https://docs.julialang.org/en/v1/base/math/#Base.Rounding.RoundDown), or
+[`RoundUp`](https://docs.julialang.org/en/v1/base/math/#Base.Rounding.RoundUp)).
 """
 function Base.round(::Type{DateTime}, dt::DateTimeProlepticGregorian,r::RoundingMode = RoundNearest)
     function round_ms(t)

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,9 +5,9 @@ end
 """
     Period{T,Tfactor,Texponent}
 
-Period wraps a number duration of type T where
+Period wraps a number duration of type `T` where
 
-duration * factor * 10^exponent
+    duration * factor * 10^exponent
 
 represents the time in seconds
 """


### PR DESCRIPTION
A few suggestions to add cross-references to various `struct`s and `function`s defined in this package. Probably missing some. Added a few example-xrefs to `AbstractCFDateTime` to a few functions, but an actual docstring + reference in the docs is probably needed for that link to work (ref: #46).

Feel free to modify as you see fit.

---

ref: https://github.com/openjournals/joss-reviews/issues/8487